### PR TITLE
Fix moment package version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test-infra"
   ],
   "dependencies": {
-    "moment": "~2.10.2",
+    "moment": "^2.10.2",
     "bootstrap": "~3.3.4",
     "jquery": "1.11.0",
     "bootstrap-material-design": "~0.3.0"


### PR DESCRIPTION
With this version pinned to patch versions of 2.10 it was
causing issues with using moment.timezome package in jell-web.