### PR TITLE
Fix Moment package dependency issue in bower 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "test-infra"
   ],
   "dependencies": {
-    "momentjs": "~2.10.2",
+    "moment": "^2.10.2",
     "bootstrap": "~3.3.4",
     "jquery": "1.11.0",
     "bootstrap-material-design": "~0.3.0"


### PR DESCRIPTION
With momentjs pinned to patch versions of 2.10 it was
causing issues with using moment.timezome package in jell-web.

The previous commit only addressed package.json and running wiredep for
bower dependencies still included old momentjs version.

Fixed in bower.json by replacing momentjs with moment and fix pinning to
minor versions.